### PR TITLE
feat: 정규표현식 기반의 watchlist 매칭 기능 추가

### DIFF
--- a/app/core/seed_loader.py
+++ b/app/core/seed_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from app.repository import targets as targets_repo
@@ -14,6 +15,15 @@ def _read_json(path: Path) -> list[dict]:
     if not isinstance(data, list):
         return []
     return [item for item in data if isinstance(item, dict)]
+
+
+def _validate_pattern(value: str) -> bool:
+    """정규표현식이 유효한지 검증한다."""
+    try:
+        re.compile(value)
+        return True
+    except re.error:
+        return False
 
 
 def load_targets_file(conn, path: Path) -> int:
@@ -35,9 +45,26 @@ def load_watchlist_file(conn, path: Path) -> int:
         item_type = str(item.get("type", "")).strip().lower()
         value = str(item.get("value", "")).strip()
         label = item.get("label")
+
         if not item_type or not value:
             continue
-        watchlist_repo.create_watchlist_item(conn, item_type=item_type, value=value, label=label)
+
+        # pattern 타입은 정규표현식 유효성 검증 후 저장
+        # target_types는 JSON 직렬화하여 label에 함께 보관하거나
+        # 별도 컬럼이 없으므로 meta 정보를 label에 prefix로 저장
+        if item_type == "pattern":
+            if not _validate_pattern(value):
+                print(f"[seed_loader] 유효하지 않은 정규표현식 건너뜀: {value!r}")
+                continue
+            # target_types가 있으면 label에 직렬화해서 붙임
+            target_types = item.get("target_types")
+            if target_types and isinstance(target_types, list):
+                meta = json.dumps({"target_types": target_types}, ensure_ascii=False)
+                label = f"{label or ''}|meta:{meta}"
+
+        watchlist_repo.create_watchlist_item(
+            conn, item_type=item_type, value=value, label=label
+        )
         count += 1
     conn.commit()
     return count

--- a/app/crawler/matcher.py
+++ b/app/crawler/matcher.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import re
 from datetime import datetime, timezone
 from hashlib import sha256
 
@@ -19,67 +21,154 @@ def _to_dt(value):
 
 def _get_alert_channels() -> list[str]:
     channels = ["stdout"]
-
     if settings.discord_webhook_url:
         channels.append("discord")
-
     if settings.telegram_bot_token and settings.telegram_chat_id:
         channels.append("telegram")
-
     return channels
 
 
-def match_and_queue_alerts(conn, *, page_id: int, extracted_items: list[dict], seen_at: str) -> list[int]:
-    watchlist = watchlist_repo.list_enabled_watchlist(conn)
-    by_type = {}
-    for item in watchlist:
-        by_type.setdefault(item["type"], {})[item["normalized"]] = item
+def _parse_pattern_entry(entry: dict) -> tuple[re.Pattern, list[str] | None]:
+    """
+    watchlist pattern 항목을 파싱하여 (컴파일된 패턴, target_types)를 반환한다.
+    target_types가 없으면 None (= 전체 타입에 적용).
+    """
+    pattern = re.compile(entry["value"])
 
-    created_hit_ids: list[int] = []
+    target_types: list[str] | None = None
+    label = entry.get("label") or ""
+    if "|meta:" in label:
+        _, meta_str = label.split("|meta:", 1)
+        try:
+            meta = json.loads(meta_str)
+            target_types = meta.get("target_types")
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    return pattern, target_types
+
+
+def _record_hit(
+    conn,
+    *,
+    page_id: int,
+    item: dict,
+    watchlist_entry: dict,
+    matched_value: str,
+    seen_at: str,
+    channels: list[str],
+) -> int:
+    """hit를 upsert하고 필요하면 알림을 생성한다. hit_id를 반환한다."""
     seen_dt = _to_dt(seen_at) or datetime.now(timezone.utc)
-    channels = _get_alert_channels()
 
+    fingerprint = sha256(
+        f"{watchlist_entry['id']}|{item['normalized']}|{page_id}".encode("utf-8")
+    ).hexdigest()
+
+    result = hits_repo.upsert_watchlist_hit(
+        conn,
+        extracted_item_id=item["id"],
+        watchlist_id=int(watchlist_entry["id"]),
+        page_id=page_id,
+        matched_value=matched_value,
+        fingerprint=fingerprint,
+        seen_at=seen_at,
+    )
+
+    should_alert = result["is_new"]
+    last_alerted_at = _to_dt(result.get("last_alerted_at"))
+
+    if not should_alert and last_alerted_at is not None:
+        should_alert = (
+            seen_dt - last_alerted_at
+        ).total_seconds() >= settings.alert_cooldown_seconds
+
+    if should_alert:
+        for channel in channels:
+            alerts_repo.create_alert(
+                conn,
+                hit_id=result["hit_id"],
+                channel=channel,
+                created_at=seen_at,
+            )
+        hits_repo.touch_last_alerted_at(
+            conn,
+            hit_id=result["hit_id"],
+            alerted_at=seen_at,
+        )
+
+    return result["hit_id"]
+
+
+def match_and_queue_alerts(
+    conn,
+    *,
+    page_id: int,
+    extracted_items: list[dict],
+    seen_at: str,
+) -> list[int]:
+    watchlist = watchlist_repo.list_enabled_watchlist(conn)
+    channels = _get_alert_channels()
+    created_hit_ids: list[int] = []
+
+    # ── 1) 기존 exact-match 항목 분류 ───────────────────────────────────────
+    by_type: dict[str, dict[str, dict]] = {}
+    pattern_entries: list[dict] = []
+
+    for entry in watchlist:
+        if entry["type"] == "pattern":
+            pattern_entries.append(entry)
+        else:
+            by_type.setdefault(entry["type"], {})[entry["normalized"]] = entry
+
+    # ── 2) Exact-match 매칭 (기존 동작 유지) ────────────────────────────────
     for item in extracted_items:
         matched = by_type.get(item["type"], {}).get(item["normalized"])
         if not matched:
             continue
 
-        fingerprint = sha256(
-            f"{matched['id']}|{item['normalized']}|{page_id}".encode("utf-8")
-        ).hexdigest()
-
-        result = hits_repo.upsert_watchlist_hit(
+        hit_id = _record_hit(
             conn,
-            extracted_item_id=item["id"],
-            watchlist_id=int(matched["id"]),
             page_id=page_id,
+            item=item,
+            watchlist_entry=matched,
             matched_value=item["raw"],
-            fingerprint=fingerprint,
             seen_at=seen_at,
+            channels=channels,
         )
+        created_hit_ids.append(hit_id)
 
-        should_alert = result["is_new"]
-        last_alerted_at = _to_dt(result.get("last_alerted_at"))
+    # ── 3) 정규표현식 패턴 매칭 (신규) ─────────────────────────────────────
+    for entry in pattern_entries:
+        try:
+            pattern, target_types = _parse_pattern_entry(entry)
+        except re.error:
+            # DB에 잘못 저장된 패턴은 건너뜀
+            continue
 
-        if not should_alert and last_alerted_at is not None:
-            should_alert = (
-                seen_dt - last_alerted_at
-            ).total_seconds() >= settings.alert_cooldown_seconds
+        for item in extracted_items:
+            # target_types 필터: 지정된 타입만 검사
+            if target_types and item["type"] not in target_types:
+                continue
 
-        if should_alert:
-            for channel in channels:
-                alerts_repo.create_alert(
-                    conn,
-                    hit_id=result["hit_id"],
-                    channel=channel,
-                    created_at=seen_at,
-                )
-            hits_repo.touch_last_alerted_at(
+            # raw 값과 normalized 값 둘 다 검사하여 매칭 범위 확대
+            search_text = item["raw"] + " " + item["normalized"]
+            m = pattern.search(search_text)
+            if not m:
+                continue
+
+            # 매칭된 텍스트를 matched_value로 기록
+            matched_value = m.group(0)
+
+            hit_id = _record_hit(
                 conn,
-                hit_id=result["hit_id"],
-                alerted_at=seen_at,
+                page_id=page_id,
+                item=item,
+                watchlist_entry=entry,
+                matched_value=matched_value,
+                seen_at=seen_at,
+                channels=channels,
             )
-
-        created_hit_ids.append(result["hit_id"])
+            created_hit_ids.append(hit_id)
 
     return created_hit_ids

--- a/watchlist.json
+++ b/watchlist.json
@@ -43,5 +43,25 @@
     "type": "btc",
     "value": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080",
     "owner": "test"
+  },
+  {
+    "type": "pattern",
+    "value": "(?i)\\b(credential|password|passwd|secret)s?\\b",
+    "label": "자격증명 키워드 탐지",
+    "owner": "test",
+    "target_types": ["url", "domain", "email"]
+  },
+  {
+    "type": "pattern",
+    "value": "01[016789][0-9]{7,8}",
+    "label": "한국 휴대폰 번호 패턴",
+    "owner": "test",
+    "target_types": ["phone"]
+  },
+  {
+    "type": "pattern",
+    "value": "(?i)xssf|h4ck|0day|exploit",
+    "label": "해킹 관련 키워드",
+    "owner": "test"
   }
 ]


### PR DESCRIPTION
- watchlist에 'pattern' 타입을 추가하여 정규표현식을 이용한 유연한 매칭 지원
- seed_loader에서 정규표현식 유효성 검증 및 target_types 메타데이터 저장 로직 구현
- matcher의 매칭 로직을 exact-match와 정규표현식 매칭으로 분리하고, 알림 생성 로직을 _record_hit으로 모듈화
- 정규표현식 매칭 시 raw 데이터와 normalized 데이터를 모두 검사하여 탐지 범위 확대